### PR TITLE
iOS 6 & CallBar support (partial)

### DIFF
--- a/Tweak.xm
+++ b/Tweak.xm
@@ -99,9 +99,7 @@ void sendSpeakerNotification (BOOL isCallBar)
 - (void)useSpeaker:(NSNotification *)notification {
     BOOL wants = [[[notification userInfo] objectForKey:@"Speaker"] boolValue];
     if (wants)
-      //dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 0.4 * NSEC_PER_SEC), dispatch_get_main_queue(), ^(void){
           [self setRouteToSpeaker];
-        //});
 }
 %end
 //On iOS 6 InCallController viewDidAppear:
@@ -117,15 +115,14 @@ void sendSpeakerNotification (BOOL isCallBar)
     %orig(arg1);
 }
 %new
-%new
 - (void)useSpeaker:(NSNotification *)notification {
     BOOL wants = [[[notification userInfo] objectForKey:@"Speaker"] boolValue];
     if (wants)
     //on iOS6 the speaker seems to
     //enable and subsequently, disable
-		  dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 0.4 * NSEC_PER_SEC), dispatch_get_main_queue(), ^(void){
-          [CHIvar(self,_inCallViewController,id) sixSquareButtonClicked: (isiOS7) ? [CHIvar(self,_inCallViewController,id) speakerButtonPosition] : 2];
-		    });
+	dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 0.4 * NSEC_PER_SEC), dispatch_get_main_queue(), ^(void){
+		[CHIvar(self,_inCallViewController,id) sixSquareButtonClicked: (isiOS7) ? [CHIvar(self,_inCallViewController,id) speakerButtonPosition] : 2];
+	x});
     //this delay seems to fix that
 }
 %end


### PR DESCRIPTION
this should support the two button (non-lockscreen) interface for iOS 6, as well as the button interface for CallBar (however not with the gestures option).
Some of the iOS 7 portion has been changed as well, however it isn't tested, so functionality isn't guaranteed. (although i used a class which seemed to be consistent between iOS 6/7) .

Feel free to review changes, and make adjustments.
